### PR TITLE
Use RHASH_SIZE instead of RHASH() to grab internals of Hash.

### DIFF
--- a/ext/birch/native.c
+++ b/ext/birch/native.c
@@ -269,7 +269,7 @@ static VALUE birch_has_feature(VALUE self, VALUE feature) {
 static VALUE birch_has_features(VALUE self) {
 	VALUE features;
 	features = rb_iv_get(self, "@features");
-  if (!RHASH(features)->ntbl) {
+  if (RHASH_SIZE(features) == 0) {
 		return Qfalse;
 	} else { return Qtrue; }
 }


### PR DESCRIPTION
On Rubinius, Hash in implemented in Ruby. RHASH() grabs internals
of how Hash is layed out in MRI. This is behavior that can't be
emulated, but with macro's / functions like RHASH_SIZE this can be
done in a compatible way.
