### PR TITLE
fix(implicit declaration of function 'RHASH' is invalid)

### DIFF
--- a/ext/birch/native.c
+++ b/ext/birch/native.c
@@ -1,4 +1,5 @@
 #include <ruby.h>
+#include <ruby/intern.h>
 
 static VALUE birch;
 static VALUE birch_tree;


### PR DESCRIPTION
## What? Why?

Compiling birch v0.0.8 against Ruby 2.2 fails with the error:
`implicit declaration of function 'RHASH' is invalid`

@faustoct supplied a fix in https://github.com/louismullie/birch/issues/11#issuecomment-78539134. This PR implements that fix. ~~I too am unsure if this is an acceptable fix but wanted to get a discussion going if not.~~ This PR only works for Ruby 2.2. I'm unsure how to address this for the other environments, but I'm leaving this open so others who are trying to use Treat on Ruby 2.2 and Rails 5 have a branch they can target.

Feel free to close or address in another way.
## How was it tested?

Using MRI, updated my Gemfile to include:
`gem "birch", github: "billthompson/birch", branch: "birch-ruby22"` 

Then ran `bundle install`. Birch was installed successfully.
